### PR TITLE
web: show requested low-star reports in UI

### DIFF
--- a/web/lib/data.ts
+++ b/web/lib/data.ts
@@ -116,6 +116,9 @@ export function isPublicReport(report: Report): boolean {
     return false;
   }
   if (isGithubBackedReport(report) && (report.stars ?? 0) < MIN_PUBLIC_GITHUB_STARS) {
+    if (report.category === "Scan Request") {
+      return true;
+    }
     return false;
   }
   return true;


### PR DESCRIPTION
## Summary
- `web/lib/data.ts` had a `stars < 50` filter that hid GitHub-backed tools with low stars
- The backend Go sync already has a `category === "Scan Request"` exception, but the frontend data loader didn't match
- This adds the same exception to `isPublicReport` so user-requested scan reports (e.g. helix-pilot) are visible in the UI regardless of star count

## Test plan
- [ ] `helix-pilot` (a Scan Request with low stars) now appears in the directory UI
- [ ] Other low-star GitHub tools without `category: "Scan Request"` remain hidden
- [ ] `npm run build` passes (SSG generates `/tool/helix-pilot.html`)
- [ ] `npm run lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)