### PR TITLE
Expand MCP discovery: seed repos, broader GitHub queries, OSSInsight source

### DIFF
--- a/cmd/crawler/main.go
+++ b/cmd/crawler/main.go
@@ -23,6 +23,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/AgentSafe-AI/tooltrust-directory/pkg/ossinsight"
 	"github.com/AgentSafe-AI/tooltrust-directory/pkg/smithery"
 	"github.com/google/go-github/v68/github"
 	"golang.org/x/oauth2"
@@ -479,6 +480,88 @@ func discoverFromOverrides(ctx context.Context, client *github.Client, overrides
 	return pending, nil
 }
 
+// discoverFromOSSInsight fetches the OSSInsight curated "MCP Servers" collection
+// (id 10105) and returns PendingScans for repos not already covered by earlier
+// discovery passes. Mirrors discoverFromSeed's structure and collision handling.
+// Non-fatal: errors and empty results are logged and silently skipped.
+func discoverFromOSSInsight(ctx context.Context, client *github.Client, existing map[string]*ExistingReport, seen map[string]bool, forceRescan bool) ([]PendingScan, error) {
+	mcpRepos, err := ossinsight.ListMCPServers()
+	if err != nil {
+		log.Printf("OSSInsight discovery: %v (skipping)", err)
+		return nil, nil // non-fatal
+	}
+	if len(mcpRepos) == 0 {
+		log.Printf("OSSInsight discovery: no repos returned (skipping)")
+		return nil, nil
+	}
+
+	var pending []PendingScan
+	for _, mcpRepo := range mcpRepos {
+		parts := strings.SplitN(mcpRepo.RepoName, "/", 2)
+		if len(parts) != 2 {
+			log.Printf("OSSInsight: skip malformed repo name %q", mcpRepo.RepoName)
+			continue
+		}
+		owner, repo := parts[0], parts[1]
+		toolID := toToolID(repo)
+		if seen[toolID] {
+			continue
+		}
+		seen[toolID] = true
+
+		ghRepo, err := cachedRepoGet(ctx, client, owner, repo)
+		if err != nil {
+			log.Printf("OSSInsight %s: %v", mcpRepo.RepoName, err)
+			continue
+		}
+		if ghRepo.GetArchived() || ghRepo.GetFork() {
+			continue
+		}
+
+		version, err := cachedLatestVersion(ctx, client, owner, repo, true)
+		if err != nil {
+			if forceRescan {
+				if cur, ok := existing[toolID]; ok {
+					version = cur.Version // rescan with last-known version
+				} else {
+					log.Printf("OSSInsight %s: no release/tag, skip (%v)", toolID, err)
+					continue
+				}
+			} else {
+				log.Printf("OSSInsight %s: no release/tag (%v)", toolID, err)
+				continue
+			}
+		}
+
+		if cur, ok := existing[toolID]; ok && cur.Version == version {
+			if !forceRescan {
+				log.Printf("up-to-date %s @ %s (ossinsight)", toolID, version)
+				continue
+			}
+		}
+
+		license := ""
+		if ghRepo.GetLicense() != nil {
+			license = ghRepo.GetLicense().GetSPDXID()
+		}
+		pending = append(pending, PendingScan{
+			ToolID:       toolID,
+			RepoOwner:    owner,
+			RepoName:     repo,
+			Version:      version,
+			SourceURL:    ghRepo.GetHTMLURL(),
+			Vendor:       owner,
+			Stars:        ghRepo.GetStargazersCount(),
+			Language:     ghRepo.GetLanguage(),
+			Category:     languageToCategory(ghRepo.GetLanguage()),
+			Description:  ghRepo.GetDescription(),
+			License:      license,
+			DiscoveredAt: time.Now().UTC(),
+		})
+	}
+	return pending, nil
+}
+
 // discoverFromSmithery fetches all Smithery servers by usage and queues
 // those not already covered by GitHub/seed discovery. Tools that have a GitHub
 // repo are enriched with stars/version data; Smithery-native tools (no GitHub)
@@ -649,6 +732,16 @@ func discoverTools(ctx context.Context, client *github.Client, existing map[stri
 		pending = append(pending, fromSeed...)
 	}
 
+	// OSSInsight discovery: curated "MCP Servers" collection (id 10105) ranked
+	// by monthly star growth — a high-signal set of canonical MCP server repos.
+	fromOSSInsight, err := discoverFromOSSInsight(ctx, client, existing, seen, forceRescan)
+	if err != nil {
+		log.Printf("OSSInsight discovery error: %v", err)
+	} else {
+		pending = append(pending, fromOSSInsight...)
+		log.Printf("OSSInsight discovery: %d tool(s) queued", len(fromOSSInsight))
+	}
+
 	// Smithery discovery: all tools by usage — covers the full Smithery catalog
 	// (~4k tools) including those with few GitHub stars or no standalone repo.
 	fromSmithery, err := discoverFromSmithery(ctx, client, existing, seen, forceRescan)
@@ -658,16 +751,25 @@ func discoverTools(ctx context.Context, client *github.Client, existing map[stri
 	pending = append(pending, fromSmithery...)
 	log.Printf("Smithery discovery: %d new tool(s) queued", len(fromSmithery))
 
-	// GitHub Search: topic-based and name-based.
-	// PerPage:100 (API max) sorted by stars captures the top ~400 repos across
-	// 4 queries. A minimum-star threshold filters out stub/test repos that
-	// crowd out genuine tools with lower star counts.
+	// GitHub Search: broader coverage across topic variants and naming conventions.
+	// PerPage:100 (API max) sorted by stars; the seen map dedups across queries.
+	// A minimum-star threshold filters out stub/test repos. Coverage expanded
+	// beyond mcp-server topic/name because the dominant convention is X-mcp /
+	// mcp-X (suffix/prefix), and many high-star repos (blender-mcp, mcp-chrome)
+	// have empty topics.
 	const minStars = 50
 	queries := []string{
+		// topic variants (maintainers tag inconsistently)
+		"topic:mcp",
 		"topic:mcp-server",
-		"mcp-server in:name language:TypeScript",
-		"mcp-server in:name language:Python",
-		"mcp-server in:name language:Go",
+		"topic:mcp-servers",
+		"topic:model-context-protocol",
+		"topic:modelcontextprotocol",
+		// naming conventions: prefix + suffix both caught by in:name
+		"mcp-server in:name",
+		"mcp in:name stars:>100",
+		// description fallback: catches empty-topic, oddly-named servers
+		"\"mcp server\" in:description stars:>200",
 	}
 
 	for _, q := range queries {

--- a/cmd/crawler/main.go
+++ b/cmd/crawler/main.go
@@ -274,15 +274,21 @@ type SmitherySeed struct {
 }
 
 // SeedOverride is an explicit tool entry for tools that cannot be reliably
-// discovered by GitHub search — typically individual servers inside a monorepo.
-// All fields except Repo are required.
+// discovered by GitHub search — typically individual servers inside a monorepo,
+// or a server whose toToolID(repo) collides with a different already-indexed
+// tool. Repo and ToolID are required.
 type SeedOverride struct {
 	// Repo is the GitHub owner/repo that contains the tool (e.g. "modelcontextprotocol/servers").
 	Repo string `json:"repo"`
 	// ToolID is the canonical kebab-case identifier for the tool (e.g. "mcp-server-filesystem").
 	ToolID string `json:"tool_id"`
-	// NPMPackage is the exact npm package name used for live scanning (e.g. "@modelcontextprotocol/server-filesystem").
-	NPMPackage string `json:"npm_package"`
+	// NPMPackage is the exact npm package name used for live scanning (e.g.
+	// "@modelcontextprotocol/server-filesystem"). Optional: leave empty for
+	// non-npm servers (Python/uvx, C#, etc.). Such entries fall through to the
+	// scan pipeline's static-tools manifest (data/static-tools/<tool_id>.json)
+	// or Smithery fallback, exactly like a GitHub-discovered repo with no npm
+	// package.
+	NPMPackage string `json:"npm_package,omitempty"`
 	// SourceURL is the canonical URL for this specific tool within the repo.
 	SourceURL string `json:"source_url"`
 }
@@ -408,8 +414,8 @@ func discoverFromSeed(ctx context.Context, client *github.Client, seed []string,
 func discoverFromOverrides(ctx context.Context, client *github.Client, overrides []SeedOverride, existing map[string]*ExistingReport, seen map[string]bool, forceRescan bool) ([]PendingScan, error) {
 	var pending []PendingScan
 	for _, ov := range overrides {
-		if ov.ToolID == "" || ov.Repo == "" || ov.NPMPackage == "" {
-			log.Printf("seed override: skipping incomplete entry %+v", ov)
+		if ov.ToolID == "" || ov.Repo == "" {
+			log.Printf("seed override: skipping incomplete entry (repo and tool_id required) %+v", ov)
 			continue
 		}
 		if seen[ov.ToolID] {

--- a/data/seed-popular.json
+++ b/data/seed-popular.json
@@ -22,7 +22,24 @@
     "ckreiling/mcp-server-docker",
     "getsentry/sentry-mcp",
     "redis/mcp-redis",
-    "jerhadf/linear-mcp-server"
+    "jerhadf/linear-mcp-server",
+    "ahujasid/blender-mcp",
+    "hangwin/mcp-chrome",
+    "idosal/git-mcp",
+    "grab/cursor-talk-to-figma-mcp",
+    "cursortouch/windows-mcp",
+    "executeautomation/mcp-playwright",
+    "21st-dev/magic-mcp",
+    "excalidraw/excalidraw-mcp",
+    "jgraph/drawio-mcp",
+    "coding-solo/godot-mcp",
+    "markuspfundstein/mcp-obsidian",
+    "zcaceres/markdownify-mcp",
+    "chongdashu/unreal-mcp",
+    "supabase-community/supabase-mcp",
+    "dbt-labs/dbt-mcp",
+    "genomoncology/biomcp",
+    "googleapis/genai-toolbox"
   ],
   "overrides": [
     {
@@ -61,6 +78,13 @@
       "tool_id": "mcp-server-sequential-thinking",
       "npm_package": "@modelcontextprotocol/server-sequential-thinking",
       "source_url": "https://github.com/modelcontextprotocol/servers/tree/main/src/sequentialthinking"
+    },
+    {
+      "_comment": "browsermcp/mcp repo name is 'mcp' which collides with awslabs/mcp (tool_id='mcp'). Use override with disambiguated tool_id and verified npm package.",
+      "repo": "browsermcp/mcp",
+      "tool_id": "browsermcp",
+      "npm_package": "@browsermcp/mcp",
+      "source_url": "https://github.com/browsermcp/mcp"
     }
   ],
   "smithery_seeds": [

--- a/data/seed-popular.json
+++ b/data/seed-popular.json
@@ -85,6 +85,12 @@
       "tool_id": "browsermcp",
       "npm_package": "@browsermcp/mcp",
       "source_url": "https://github.com/browsermcp/mcp"
+    },
+    {
+      "_comment": "CoplayDev/unity-mcp (10.7k stars) collides on tool_id 'unity-mcp' with the already-indexed IvanMurzak/Unity-MCP. Disambiguate with a vendor prefix (same convention as cameroncooke-xcodebuildmcp / tavily-ai-tavily-mcp). Non-npm (Python/uvx; npm 'unity-mcp' is an unrelated repo), so no npm_package — scanned via data/static-tools/coplaydev-unity-mcp.json.",
+      "repo": "CoplayDev/unity-mcp",
+      "tool_id": "coplaydev-unity-mcp",
+      "source_url": "https://github.com/CoplayDev/unity-mcp"
     }
   ],
   "smithery_seeds": [

--- a/data/static-tools/coplaydev-unity-mcp.json
+++ b/data/static-tools/coplaydev-unity-mcp.json
@@ -1,0 +1,348 @@
+{
+  "tools": [
+    {
+      "name": "apply_text_edits",
+      "description": "Apply text edits to script content",
+      "inputSchema": {
+        "type": "object",
+        "properties": {}
+      }
+    },
+    {
+      "name": "batch_execute",
+      "description": "Execute multiple Unity operations in a single batch",
+      "inputSchema": {
+        "type": "object",
+        "properties": {}
+      }
+    },
+    {
+      "name": "create_script",
+      "description": "Create new C# scripts",
+      "inputSchema": {
+        "type": "object",
+        "properties": {}
+      }
+    },
+    {
+      "name": "debug_request_context",
+      "description": "Debug and inspect MCP request context",
+      "inputSchema": {
+        "type": "object",
+        "properties": {}
+      }
+    },
+    {
+      "name": "delete_script",
+      "description": "Delete C# scripts",
+      "inputSchema": {
+        "type": "object",
+        "properties": {}
+      }
+    },
+    {
+      "name": "execute_custom_tool",
+      "description": "Execute custom Unity Editor tools registered by the project",
+      "inputSchema": {
+        "type": "object",
+        "properties": {}
+      }
+    },
+    {
+      "name": "execute_code",
+      "description": "Execute arbitrary C# code inside the Unity Editor with access to all Unity APIs",
+      "inputSchema": {
+        "type": "object",
+        "properties": {}
+      }
+    },
+    {
+      "name": "execute_menu_item",
+      "description": "Execute Unity Editor menu items",
+      "inputSchema": {
+        "type": "object",
+        "properties": {}
+      }
+    },
+    {
+      "name": "find_gameobjects",
+      "description": "Find GameObjects in the scene by various criteria",
+      "inputSchema": {
+        "type": "object",
+        "properties": {}
+      }
+    },
+    {
+      "name": "find_in_file",
+      "description": "Search for content within Unity project files",
+      "inputSchema": {
+        "type": "object",
+        "properties": {}
+      }
+    },
+    {
+      "name": "get_sha",
+      "description": "Get SHA hash of script content",
+      "inputSchema": {
+        "type": "object",
+        "properties": {}
+      }
+    },
+    {
+      "name": "get_test_job",
+      "description": "Get status of async test job",
+      "inputSchema": {
+        "type": "object",
+        "properties": {}
+      }
+    },
+    {
+      "name": "manage_animation",
+      "description": "Manage Unity animation: Animator control, AnimatorController CRUD, and AnimationClip operations",
+      "inputSchema": {
+        "type": "object",
+        "properties": {}
+      }
+    },
+    {
+      "name": "manage_asset",
+      "description": "Create, modify, search, and organize Unity assets",
+      "inputSchema": {
+        "type": "object",
+        "properties": {}
+      }
+    },
+    {
+      "name": "manage_build",
+      "description": "Manage player builds: trigger builds, switch platforms, configure settings, batch builds",
+      "inputSchema": {
+        "type": "object",
+        "properties": {}
+      }
+    },
+    {
+      "name": "manage_components",
+      "description": "Add, remove, and configure GameObject components",
+      "inputSchema": {
+        "type": "object",
+        "properties": {}
+      }
+    },
+    {
+      "name": "manage_editor",
+      "description": "Control Unity Editor state, play mode, preferences, undo/redo",
+      "inputSchema": {
+        "type": "object",
+        "properties": {}
+      }
+    },
+    {
+      "name": "manage_gameobject",
+      "description": "Create, modify, transform, and delete GameObjects",
+      "inputSchema": {
+        "type": "object",
+        "properties": {}
+      }
+    },
+    {
+      "name": "manage_camera",
+      "description": "Manage cameras (Unity Camera + Cinemachine) with presets, pipelines, and blending",
+      "inputSchema": {
+        "type": "object",
+        "properties": {}
+      }
+    },
+    {
+      "name": "manage_graphics",
+      "description": "Manage rendering graphics: volumes, post-processing, light baking, rendering stats, pipeline settings, and URP renderer features",
+      "inputSchema": {
+        "type": "object",
+        "properties": {}
+      }
+    },
+    {
+      "name": "manage_material",
+      "description": "Create and modify Unity materials and shaders",
+      "inputSchema": {
+        "type": "object",
+        "properties": {}
+      }
+    },
+    {
+      "name": "manage_packages",
+      "description": "Modify Unity packages: install, remove, embed, and configure registries",
+      "inputSchema": {
+        "type": "object",
+        "properties": {}
+      }
+    },
+    {
+      "name": "manage_physics",
+      "description": "Manage 3D and 2D physics: settings, collision matrix, materials, joints, queries (raycast, shapecast, linecast, overlap), forces, rigidbody configuration, validation, and simulation",
+      "inputSchema": {
+        "type": "object",
+        "properties": {}
+      }
+    },
+    {
+      "name": "manage_prefabs",
+      "description": "Create, instantiate, unpack, and modify prefabs",
+      "inputSchema": {
+        "type": "object",
+        "properties": {}
+      }
+    },
+    {
+      "name": "manage_probuilder",
+      "description": "Create and edit ProBuilder meshes, shapes, and geometry operations",
+      "inputSchema": {
+        "type": "object",
+        "properties": {}
+      }
+    },
+    {
+      "name": "manage_profiler",
+      "description": "Unity Profiler session control, counter reads, memory snapshots, and Frame Debugger (group: profiling)",
+      "inputSchema": {
+        "type": "object",
+        "properties": {}
+      }
+    },
+    {
+      "name": "manage_scene",
+      "description": "Load, save, query hierarchy, multi-scene editing, templates, validation, and manage Unity scenes",
+      "inputSchema": {
+        "type": "object",
+        "properties": {}
+      }
+    },
+    {
+      "name": "manage_script",
+      "description": "Create, read, and modify C# scripts",
+      "inputSchema": {
+        "type": "object",
+        "properties": {}
+      }
+    },
+    {
+      "name": "manage_script_capabilities",
+      "description": "Query script management capabilities",
+      "inputSchema": {
+        "type": "object",
+        "properties": {}
+      }
+    },
+    {
+      "name": "manage_scriptable_object",
+      "description": "Create and modify ScriptableObjects",
+      "inputSchema": {
+        "type": "object",
+        "properties": {}
+      }
+    },
+    {
+      "name": "manage_shader",
+      "description": "Work with Unity shaders",
+      "inputSchema": {
+        "type": "object",
+        "properties": {}
+      }
+    },
+    {
+      "name": "manage_texture",
+      "description": "Create and modify textures with patterns, gradients, and noise",
+      "inputSchema": {
+        "type": "object",
+        "properties": {}
+      }
+    },
+    {
+      "name": "manage_tools",
+      "description": "Manage which tool groups are visible in this session",
+      "inputSchema": {
+        "type": "object",
+        "properties": {}
+      }
+    },
+    {
+      "name": "manage_ui",
+      "description": "Manage Unity UI Toolkit elements (UXML documents, USS stylesheets, UIDocument components)",
+      "inputSchema": {
+        "type": "object",
+        "properties": {}
+      }
+    },
+    {
+      "name": "manage_vfx",
+      "description": "Manage Visual Effects, particle systems, and trails",
+      "inputSchema": {
+        "type": "object",
+        "properties": {}
+      }
+    },
+    {
+      "name": "read_console",
+      "description": "Read Unity Editor console output (logs, warnings, errors)",
+      "inputSchema": {
+        "type": "object",
+        "properties": {}
+      }
+    },
+    {
+      "name": "refresh_unity",
+      "description": "Refresh Unity Editor asset database",
+      "inputSchema": {
+        "type": "object",
+        "properties": {}
+      }
+    },
+    {
+      "name": "run_tests",
+      "description": "Run Unity Test Framework tests",
+      "inputSchema": {
+        "type": "object",
+        "properties": {}
+      }
+    },
+    {
+      "name": "script_apply_edits",
+      "description": "Apply code edits to C# scripts with validation",
+      "inputSchema": {
+        "type": "object",
+        "properties": {}
+      }
+    },
+    {
+      "name": "set_active_instance",
+      "description": "Set the active Unity Editor instance for multi-instance workflows",
+      "inputSchema": {
+        "type": "object",
+        "properties": {}
+      }
+    },
+    {
+      "name": "unity_docs",
+      "description": "Fetch Unity documentation (ScriptReference, Manual, package docs)",
+      "inputSchema": {
+        "type": "object",
+        "properties": {}
+      }
+    },
+    {
+      "name": "unity_reflect",
+      "description": "Inspect Unity C# APIs via live reflection",
+      "inputSchema": {
+        "type": "object",
+        "properties": {}
+      }
+    },
+    {
+      "name": "validate_script",
+      "description": "Validate C# script syntax and compilation",
+      "inputSchema": {
+        "type": "object",
+        "properties": {}
+      }
+    }
+  ]
+}

--- a/pkg/ossinsight/discovery.go
+++ b/pkg/ossinsight/discovery.go
@@ -1,0 +1,112 @@
+// Package ossinsight fetches OSSInsight's curated "MCP Servers" collection
+// (a high-signal, hand-curated list of canonical MCP server repos) for use as
+// a crawler discovery seed.
+package ossinsight
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"time"
+)
+
+const (
+	ossinsightBaseURL      = "https://api.ossinsight.io/v1"
+	ossinsightTimeout      = 30 * time.Second
+	mcpServersCollectionID = 10105
+)
+
+// MCPRepo is one repo in the OSSInsight MCP Servers collection.
+type MCPRepo struct {
+	RepoName string // "owner/repo"
+	Growth   int    // current-period star growth (trending signal)
+}
+
+// ossinsightResponse is the top-level shape of the OSSInsight ranking endpoint.
+type ossinsightResponse struct {
+	Type string `json:"type"`
+	Data struct {
+		Columns []struct {
+			Col      string `json:"col"`
+			DataType string `json:"data_type"`
+		} `json:"columns"`
+		Rows []struct {
+			RepoName            string `json:"repo_name"`
+			CurrentPeriodGrowth string `json:"current_period_growth"`
+		} `json:"rows"`
+	} `json:"data"`
+}
+
+// ListMCPServers fetches the MCP Servers collection ranked by star growth for
+// the current calendar month, falling back to the previous month if the
+// current month has no data yet. Returns a nil slice (not an error) on any
+// failure, so callers treat it as a non-fatal seed.
+func ListMCPServers() ([]MCPRepo, error) {
+	client := &http.Client{Timeout: ossinsightTimeout}
+
+	now := time.Now().UTC()
+	month := now.Format("2006-01")
+	repos, err := fetchForMonth(client, month)
+	if err != nil {
+		log.Printf("OSSInsight: fetch for %s failed: %v", month, err)
+		return nil, nil
+	}
+
+	if len(repos) == 0 {
+		// Current month has no data yet — fall back to previous month.
+		prevMonth := now.AddDate(0, -1, 0).Format("2006-01")
+		log.Printf("OSSInsight: no data for %s, falling back to %s", month, prevMonth)
+		repos, err = fetchForMonth(client, prevMonth)
+		if err != nil {
+			log.Printf("OSSInsight: fetch for %s failed: %v", prevMonth, err)
+			return nil, nil
+		}
+		if len(repos) == 0 {
+			log.Printf("OSSInsight: no data for %s either, skipping", prevMonth)
+			return nil, nil
+		}
+	}
+
+	return repos, nil
+}
+
+// fetchForMonth performs one GET request for the given calendar month (YYYY-MM)
+// and returns the parsed repo list.
+func fetchForMonth(client *http.Client, month string) ([]MCPRepo, error) {
+	apiURL := fmt.Sprintf("%s/collections/%d/ranking_by_stars/?calendar_month=%s",
+		ossinsightBaseURL, mcpServersCollectionID, month)
+
+	resp, err := client.Get(apiURL)
+	if err != nil {
+		return nil, fmt.Errorf("GET %s: %w", apiURL, err)
+	}
+	body, readErr := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	if readErr != nil {
+		return nil, fmt.Errorf("read response: %w", readErr)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("HTTP %d: %s", resp.StatusCode, body)
+	}
+
+	var osr ossinsightResponse
+	if err := json.Unmarshal(body, &osr); err != nil {
+		return nil, fmt.Errorf("decode response: %w", err)
+	}
+
+	var repos []MCPRepo
+	for _, row := range osr.Data.Rows {
+		if row.RepoName == "" {
+			continue
+		}
+		var growth int
+		fmt.Sscanf(row.CurrentPeriodGrowth, "%d", &growth)
+		repos = append(repos, MCPRepo{
+			RepoName: row.RepoName,
+			Growth:   growth,
+		})
+	}
+	return repos, nil
+}

--- a/pkg/ossinsight/discovery_test.go
+++ b/pkg/ossinsight/discovery_test.go
@@ -1,0 +1,67 @@
+package ossinsight
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+)
+
+func TestParseOSSInsightResponse(t *testing.T) {
+	// Captured subset of the real OSSInsight response shape.
+	raw := `{
+		"type": "sql_endpoint",
+		"data": {
+			"columns": [
+				{"col": "repo_id", "data_type": "BIGINT", "nullable": false},
+				{"col": "repo_name", "data_type": "VARCHAR", "nullable": false},
+				{"col": "current_period_growth", "data_type": "BIGINT", "nullable": false}
+			],
+			"rows": [
+				{"repo_name": "upstash/context7", "current_period_growth": "100"},
+				{"repo_name": "microsoft/playwright-mcp", "current_period_growth": "59"},
+				{"repo_name": "github/github-mcp-server", "current_period_growth": "46"}
+			]
+		}
+	}`
+
+	var osr ossinsightResponse
+	if err := json.Unmarshal([]byte(raw), &osr); err != nil {
+		t.Fatalf("unmarshal failed: %v", err)
+	}
+
+	if len(osr.Data.Rows) != 3 {
+		t.Fatalf("expected 3 rows, got %d", len(osr.Data.Rows))
+	}
+
+	rows := osr.Data.Rows
+	if rows[0].RepoName != "upstash/context7" {
+		t.Errorf("row[0].RepoName = %q, want %q", rows[0].RepoName, "upstash/context7")
+	}
+	if rows[0].CurrentPeriodGrowth != "100" {
+		t.Errorf("row[0].CurrentPeriodGrowth = %q, want %q", rows[0].CurrentPeriodGrowth, "100")
+	}
+
+	// Verify the full parsing pipeline (repo list extraction).
+	var repos []MCPRepo
+	for _, row := range osr.Data.Rows {
+		if row.RepoName == "" {
+			continue
+		}
+		var growth int
+		_, _ = fmt.Sscanf(row.CurrentPeriodGrowth, "%d", &growth)
+		repos = append(repos, MCPRepo{RepoName: row.RepoName, Growth: growth})
+	}
+
+	if len(repos) != 3 {
+		t.Fatalf("expected 3 MCPRepo entries, got %d", len(repos))
+	}
+	if repos[0].RepoName != "upstash/context7" {
+		t.Errorf("repos[0].RepoName = %q, want %q", repos[0].RepoName, "upstash/context7")
+	}
+	if repos[0].Growth != 100 {
+		t.Errorf("repos[0].Growth = %d, want %d", repos[0].Growth, 100)
+	}
+	if repos[1].RepoName != "microsoft/playwright-mcp" {
+		t.Errorf("repos[1].RepoName = %q, want %q", repos[1].RepoName, "microsoft/playwright-mcp")
+	}
+}


### PR DESCRIPTION
## What

Closes a structural gap in crawler discovery: high-star MCP servers (incl. `blender-mcp` at 22k★, `mcp-chrome` at 11k★) were never picked up. Three layers + a collision fix.

### Layer 1 — seed repos (`data/seed-popular.json`)
Add 17 confirmed-missing genuine MCP servers to `repos[]` (blender-mcp, mcp-chrome, mcp-playwright, godot-mcp, supabase-mcp, dbt-mcp, biomcp, …) plus `browsermcp/mcp` via override (npm `@browsermcp/mcp` verified; repo name `mcp` would collide with `awslabs/mcp`).

### Layer 2 — broaden GitHub search (root cause)
Old queries assumed the `mcp-server` topic/name convention, but the dominant convention is `X-mcp` / `mcp-X` and many high-star repos have **empty topics**. Replace the 4 narrow queries with 8 covering topic variants + naming conventions + a description fallback.

**Measured yield** (mirroring crawler selection: stars≥50, top-100/query): 559 unique repos, **394 not yet in the directory** — vs only 93 the old queries reach. ~135 are genuine MCP servers after filtering out frameworks/clients/awesome-lists; the rest is long tail.

### Layer 3 — OSSInsight source (`pkg/ossinsight`)
New non-fatal seed reading OSSInsight's curated "MCP Servers" collection (id 10105) with monthly star-growth — a high-signal set of canonical MCP repos + a trending signal. Wired into `discoverTools` before the Smithery pass.

### Collision fix — CoplayDev/unity-mcp
The most popular Unity MCP (10.7k★) was missing: `toToolID` collides with the already-indexed `IvanMurzak/Unity-MCP` (3.2k★), and it's non-npm (Python/uvx; npm `unity-mcp` is the unrelated `Artmann/unity-mcp`). Relaxed `SeedOverride` to make `npm_package` optional, added it as `coplaydev-unity-mcp` (vendor-prefix convention), and curated `data/static-tools/coplaydev-unity-mcp.json` (43 tools). IvanMurzak keeps the canonical slug — no URL breakage.

## Verification
- `gofmt`, `go build ./...`, `go vet ./...`, `go test ./...` all pass (incl. new `pkg/ossinsight` test).
- `seed-popular.json` and the new static manifest validate as JSON.
- CoplayDev static-manifest scan (v0.3.16) yields **AS-006 ×2 Critical** (`execute_code` runs arbitrary C#), grade C — a real finding, not an artificial clean grade.

## Notes
- The gh-search yield measures the *discovery* step; the crawler additionally skips repos with no release/tag (unless force-rescan), so the queued count may be somewhat lower.
- No scan results are committed here; these changes take effect on the next daily crawl.

🤖 Generated with [Claude Code](https://claude.com/claude-code)