### PR TITLE
Cut Vercel ISR reads from crawler-driven sitemap recrawls

### DIFF
--- a/web/app/robots.ts
+++ b/web/app/robots.ts
@@ -1,5 +1,8 @@
 import type { MetadataRoute } from "next";
 
+// Static — robots rules never change at runtime.
+export const dynamic = "force-static";
+
 export default function robots(): MetadataRoute.Robots {
   return {
     rules: {

--- a/web/app/sitemap.ts
+++ b/web/app/sitemap.ts
@@ -3,26 +3,36 @@ import { getAllReports } from "@/lib/data";
 
 const siteUrl = "https://www.tooltrust.dev";
 
+// Prerender the sitemap once at build time. Without this the route can be
+// regenerated on every crawler request, re-reading all ~2k report files and
+// counting against Vercel ISR reads. The sitemap only changes when a new build
+// ships, so static generation is correct.
+export const dynamic = "force-static";
+
 export default function sitemap(): MetadataRoute.Sitemap {
   const staticPages: MetadataRoute.Sitemap = [
     {
       url: siteUrl,
       lastModified: new Date(),
-      changeFrequency: "daily",
+      changeFrequency: "weekly",
       priority: 1,
     },
     {
       url: `${siteUrl}/methodology`,
       lastModified: new Date(),
-      changeFrequency: "weekly",
+      changeFrequency: "monthly",
       priority: 0.8,
     },
   ];
 
+  // Reports change only when a tool is re-scanned (≈monthly), not daily.
+  // Advertising "daily" invites crawlers (Google/Bing/AI bots) to recrawl all
+  // ~2k tool pages every day, which dominated Vercel ISR read usage.
+  // lastModified (from scan_date) still lets crawlers detect genuine changes.
   const toolPages: MetadataRoute.Sitemap = getAllReports().map((report) => ({
     url: `${siteUrl}/tool/${report.tool_id}`,
     lastModified: report.scan_date ? new Date(report.scan_date) : new Date(),
-    changeFrequency: "daily",
+    changeFrequency: "monthly",
     priority: 0.7,
   }));
 


### PR DESCRIPTION
## Problem
Vercel free-tier ISR Reads hit 75% of the 1M/mo limit (auto-pause risk). With ~2k tool pages but only ~2k **human** page views/mo, the reads are almost entirely crawler-driven: ~360 reads/page/mo ≈ 12/day — consistent with Google/Bing/AI bots recrawling every page daily.

## Root cause
`sitemap.ts` advertised `changeFrequency: "daily"` for the homepage **and all ~2k tool pages**, telling crawlers to recrawl everything daily. Reports actually change only on re-scan (~monthly).

## Fix
- `sitemap.ts` + `robots.ts` → `force-static` (prerendered once at build, not regenerated per crawler request — each regen re-read all ~2k report JSON files).
- tool pages `changeFrequency` daily → **monthly**; homepage daily → **weekly**. `lastModified` (from `scan_date`) still lets crawlers detect genuine changes, so index freshness is preserved.
- Crawlers are still fully allowed (mission = discoverability); we only stop advertising false daily churn.

## Verification
`npm run build`: `/sitemap.xml` and `/robots.txt` both render as `○ (Static)`; all routes Static/SSG, no dynamic server routes.

## Note
Pages were already `force-static` SSG — the code wasn't doing per-request ISR. This removes the *crawl pressure* generating cold reads. Reads also reset monthly, so combined with this the next cycle should drop sharply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)