### PR TITLE
fix: add static-tools manifest for puppeteer-mcp-server

### DIFF
--- a/data/static-tools/puppeteer-mcp-server.json
+++ b/data/static-tools/puppeteer-mcp-server.json
@@ -1,0 +1,156 @@
+{
+  "tools": [
+    {
+      "name": "puppeteer_connect_active_tab",
+      "description": "Connect to an existing Chrome instance with remote debugging enabled",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "targetUrl": {
+            "type": "string",
+            "description": "Optional URL of the target tab to connect to. If not provided, connects to the first available tab."
+          },
+          "debugPort": {
+            "type": "number",
+            "description": "Optional Chrome debugging port (default: 9222)",
+            "default": 9222
+          }
+        },
+        "required": []
+      }
+    },
+    {
+      "name": "puppeteer_navigate",
+      "description": "Navigate to a URL",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "url": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "url"
+        ]
+      }
+    },
+    {
+      "name": "puppeteer_screenshot",
+      "description": "Take a screenshot of the current page or a specific element",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "Name for the screenshot"
+          },
+          "selector": {
+            "type": "string",
+            "description": "CSS selector for element to screenshot"
+          },
+          "width": {
+            "type": "number",
+            "description": "Width in pixels (default: 800)"
+          },
+          "height": {
+            "type": "number",
+            "description": "Height in pixels (default: 600)"
+          }
+        },
+        "required": [
+          "name"
+        ]
+      }
+    },
+    {
+      "name": "puppeteer_click",
+      "description": "Click an element on the page",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "selector": {
+            "type": "string",
+            "description": "CSS selector for element to click"
+          }
+        },
+        "required": [
+          "selector"
+        ]
+      }
+    },
+    {
+      "name": "puppeteer_fill",
+      "description": "Fill out an input field",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "selector": {
+            "type": "string",
+            "description": "CSS selector for input field"
+          },
+          "value": {
+            "type": "string",
+            "description": "Value to fill"
+          }
+        },
+        "required": [
+          "selector",
+          "value"
+        ]
+      }
+    },
+    {
+      "name": "puppeteer_select",
+      "description": "Select an element on the page with Select tag",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "selector": {
+            "type": "string",
+            "description": "CSS selector for element to select"
+          },
+          "value": {
+            "type": "string",
+            "description": "Value to select"
+          }
+        },
+        "required": [
+          "selector",
+          "value"
+        ]
+      }
+    },
+    {
+      "name": "puppeteer_hover",
+      "description": "Hover an element on the page",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "selector": {
+            "type": "string",
+            "description": "CSS selector for element to hover"
+          }
+        },
+        "required": [
+          "selector"
+        ]
+      }
+    },
+    {
+      "name": "puppeteer_evaluate",
+      "description": "Execute JavaScript in the browser console",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "script": {
+            "type": "string",
+            "description": "JavaScript code to execute"
+          }
+        },
+        "required": [
+          "script"
+        ]
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Problem

[`puppeteer-mcp-server`](https://www.tooltrust.dev/tool/puppeteer-mcp-server) is a **TypeScript** tool, yet its report shows 8 AS-004 supply-chain findings for `GO-2026-5024 in golang.org/x/sys` — a **Go** dependency it doesn't have.

Root cause: the report is **stale** (`scanner: v0.3.15`). Those Go findings are the host-attribution false positive — the CI runner's own `tooltrust-directory` `go.sum` was wrongly attributed to the scanned tool (`dependency_note: "Local dependency artifacts scanned from /home/runner/work/tooltrust-directory/..."`). That bug was fixed in tooltrust-scanner v0.3.16 (#64), but puppeteer-mcp-server needs Chromium to boot, so its live scan fails/times out in CI and the stale pre-fix report is preserved across rescans.

## Fix

Add `data/static-tools/puppeteer-mcp-server.json` so the daily-audit **Tier 3.4 static-override** path can scan it from a curated manifest without booting a browser. Tool definitions (8 tools) were extracted from the live server's `tools/list`.

## Verified (static scan, scanner v0.3.17)

| | stale report | with override |
|---|---|---|
| grade | D/57 | **C/27** |
| AS-004 (fake Go CVEs) | 8 | **0** |
| remaining flag | — | AS-006 Critical on `puppeteer_evaluate` (legitimate in-page JS execution) |

The resulting C is correct: `puppeteer_evaluate` genuinely executes arbitrary JavaScript in the page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)