### PR TITLE
Switch to static export to eliminate Vercel ISR Reads

### DIFF
--- a/web/app/icon.tsx
+++ b/web/app/icon.tsx
@@ -1,5 +1,7 @@
 import { ImageResponse } from "next/og";
 
+export const dynamic = "force-static";
+
 export const size = {
   width: 64,
   height: 64,

--- a/web/app/opengraph-image.tsx
+++ b/web/app/opengraph-image.tsx
@@ -1,5 +1,7 @@
 import { ImageResponse } from "next/og";
 
+export const dynamic = "force-static";
+
 export const size = {
   width: 1200,
   height: 630,

--- a/web/next.config.ts
+++ b/web/next.config.ts
@@ -1,5 +1,13 @@
 import type { NextConfig } from "next";
 
-const nextConfig: NextConfig = {};
+const nextConfig: NextConfig = {
+  // Fully static HTML export. The directory is pure SSG (no server routes,
+  // middleware, server actions, or runtime data fetching), so exporting to
+  // plain static files lets Vercel serve them as CDN assets instead of through
+  // the ISR/prerender cache — which was consuming ~1M ISR Reads/mo from
+  // crawler-driven edge-cache misses across ~2k tool pages.
+  output: "export",
+  images: { unoptimized: true },
+};
 
 export default nextConfig;


### PR DESCRIPTION
## Problem
Hit **100%** of the 1M/mo free-tier **ISR Reads** → projects auto-pause. The earlier sitemap `changeFrequency` fix (#11) did **not** help — reads still maxed out.

## Real root cause
On Vercel, `force-static` App Router pages are **still read from the ISR durable store on every CDN edge-cache miss**. With ~2k low-traffic tool pages constantly crawled (Google/Bing/AI bots), the edge cache misses constantly → each miss = 1 ISR Read. `force-static` and changeFrequency don't change this — the pages are still in the ISR/prerender system.

## Fix: full static export
`output: "export"` removes the pages from the ISR/prerender system entirely — Vercel serves plain HTML/PNG as **CDN static assets, which don't count as ISR Reads**.

The app qualifies (verified on `main`): no middleware, route handlers, server actions, runtime data fetching, `force-dynamic`, `revalidate`, or `next/image`. All pages are `dynamicParams=false` SSG.

Changes:
- `next.config.ts`: `output: "export"` + `images.unoptimized`.
- `opengraph-image.tsx` / `icon.tsx`: add `export const dynamic = "force-static"` (export requires this for `next/og` ImageResponse routes).

## Verification
`npm run build` produces `out/` with: `index.html`, all `tool/*.html` (1500 locally / 2k+ on main), `sitemap.xml`, `robots.txt`, and valid `opengraph-image` (1200×630) + `icon` (64×64) PNGs.

## No functional change
Data already only updated on rebuild (crawler push → redeploy). Static export keeps exactly that behavior. Expected ISR Reads after deploy: **~0**.

## Note
Vercel auto-detects `output: export` and serves `out/` statically — no dashboard change needed. If reads don't drop to ~0 after deploy, the remaining lever is the Pro plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)